### PR TITLE
Add cjs and mjs icons

### DIFF
--- a/src/icon-settings.json
+++ b/src/icon-settings.json
@@ -529,6 +529,8 @@
 			"fileExtensions": [
 				"js",
 				"ejs",
+				"cjs",
+				"mjs",
 				"esx"
 			],
 			"fileNames": []


### PR DESCRIPTION
.cjs is the extension for commonjs, mjs for es modules.